### PR TITLE
Remove Jira track filter

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 import json
 import requests
 
-JIRA_API_QUERY='https://jira.greenpeace.org/rest/api/2/search?jql=project%20%3D%20PLANET%20AND%20status%20in%20(%22IN%20PROGRESS%22%2C%20%22IN%20DEVELOPMENT%22%2C%20%22IN%20TESTING%22%2C%20%22In%20Review%22)%20AND%20Track%20in%20(Development%2C%20Infrastructure)&fields=summary,customfield_13000'
+JIRA_API_QUERY='https://jira.greenpeace.org/rest/api/2/search?jql=project%20%3D%20PLANET%20AND%20status%20in%20(%22IN%20PROGRESS%22%2C%20%22IN%20DEVELOPMENT%22%2C%20%22IN%20TESTING%22%2C%20%22In%20Review%22)&fields=summary,customfield_13000'
 
 # https://namingschemes.com/Solar_System
 SWARM = {


### PR DESCRIPTION
The field is suddenly not accessible anymore when creating new tickets.
As a result booking an instance using the Jira ticket was not working anymore.

Removing the track filter shouldn't pose any issues, it's unlikely for someone to by accident put this on a ticket. And if it occurs it's easy to fix.

We can check if Jira track field can be disabled conditionally based on track.